### PR TITLE
Update /lead ping channel logic

### DIFF
--- a/locales/en-US/lead.ftl
+++ b/locales/en-US/lead.ftl
@@ -43,7 +43,7 @@ ping-description = Ping Your State Role
 ping-role-description = Role to ping, otherwise one of your state roles
 ping-channel-description = Channel where the ping will be sent
 ping-message-description = Message you wish to add to the ping
-ping-cant-send = Message Can't be sent in this {$Channel}
+ping-cant-send = Message can't be sent in this {$channel}
 ping-not-no-perms = {$user} does not have permission to send message
 ping-success = Ping message has been sent {$url}
 
@@ -51,7 +51,7 @@ ping-success = Ping message has been sent {$url}
 ### Command
 member-list-name = member-list
 member-list-description = Exports a list of the users in each role as a csv file
-### Commabd Options
+### Command Options
 member-list-role-option-name = target
 member-list-role-option-description = The role from with to get list
 

--- a/src/commands/chat/execution/lead/ping.ts
+++ b/src/commands/chat/execution/lead/ping.ts
@@ -19,28 +19,10 @@ export default async function ping(interaction: ChatInputCommandInteraction<'cac
 	await interaction.deferReply({ ephemeral: true });
 
 	// Get the channel option from the interaction's options, if provided.
-	let channel = interaction.options.getChannel('channel', false, [ChannelType.GuildText]);
-
-	// Check if the channel option is defined.
-	if (!channel) {
-		// Check if the command was sent from a GuildText channel.
-		if (interaction.channel.type !== ChannelType.GuildText) {
-			// If not, send an error response indicating that the command cannot be sent.
-			return interaction.followUp({
-				content: t({
-					key: 'ping-cant-send',
-					locale,
-					ns,
-					args: { channel: channel.toString() }
-				})
-			});
-		}
-		// If the channel option is not provided, set the channel to the channel where the command was used.
-		channel = interaction.channel;
-	}
+	const channel = interaction.options.getChannel('channel', false, [ChannelType.GuildText]) || interaction.channel;
 
 	// Check if the bot has permission to send messages in the channel.
-	if (!channel.permissionsFor(interaction.client.user).has(PermissionFlagsBits.SendMessages)) {
+	if (channel.guild && !channel.permissionsFor(interaction.client.user).has(PermissionFlagsBits.SendMessages)) {
 		// If not, send an error response indicating that the bot does not have permission to send messages.
 		return interaction.followUp({
 			content: t({


### PR DESCRIPTION
Since all guild channels support text, the check is unnecessary. Previously it caused an issue with the channel being undefined in that if block, but this is a more apt solution. I also slightly touch on some characters in the language file related to the command.