### PR TITLE
Indicate who is triggering the /lead ping cmd

### DIFF
--- a/src/commands/chat/execution/lead/ping.ts
+++ b/src/commands/chat/execution/lead/ping.ts
@@ -44,6 +44,8 @@ export default async function ping(interaction: ChatInputCommandInteraction<'cac
 		pingMessage.content += `\n${message}`;
 	}
 
+	pingMessage.content += `\n> Sent by ${interaction.user}`;
+
 	try {
 		// Send the ping message to the channel.
 		const sentMessage = await channel.send(pingMessage);


### PR DESCRIPTION
It's unclear who runs the command which can lead to abuse, this fixes that.

- [x] - There are no unrelated changes
- [x] - Running `yarn test` does not throw any errors
- [x] - I ran `yarn lint` to make sure my codebase is consistent
- [x] - I link to the relevant issues to be closed, if applicable
