### PR TITLE
use channel for lead state ping

### DIFF
--- a/locales/en-US/lead.ftl
+++ b/locales/en-US/lead.ftl
@@ -81,6 +81,7 @@ event-success-button-chat = Text Channel
 event-select-menu = Select Roles or members
 event-select-reply = Permission Override Updated
 event-channel-bad-category = Please choose a channel in the event category
+ping-no-state-role = There was no state role for this channel, please contact staff
 
 ### Event Modals
 modal-title-event-create = Create Event

--- a/src/commands/chat/builders/lead.ts
+++ b/src/commands/chat/builders/lead.ts
@@ -121,23 +121,6 @@ export default new ChatInputCommand()
 					.setDescription(t({ key: 'ping-description', ns }))
 					.setNameLocalizations(localization('ping-name', ns))
 					.setDescriptionLocalizations(localization('ping-description', ns))
-					.addRoleOption((option) =>
-						option
-							.setName(t({ key: 'role', ns }))
-							.setDescription(t({ key: 'ping-role-description', ns }))
-							.setNameLocalizations(localization('role', ns))
-							.setDescriptionLocalizations(localization('ping-role-description', ns))
-							.setRequired(true)
-					)
-					.addChannelOption((option) =>
-						option
-							.setName(t({ key: 'channel', ns }))
-							.setDescription(t({ key: 'ping-channel-description', ns }))
-							.setNameLocalizations(localization('channel', ns))
-							.setDescriptionLocalizations(localization('ping-channel-description', ns))
-							.addChannelTypes(ChannelType.GuildText)
-							.setRequired(false)
-					)
 					.addStringOption((option) =>
 						option
 							.setName(t({ key: 'message', ns }))

--- a/src/commands/chat/execution/lead/ping.ts
+++ b/src/commands/chat/execution/lead/ping.ts
@@ -2,7 +2,7 @@ import { ns } from '@builders/lead';
 import { t } from '@i18n';
 import { logger } from '@progressive-victory/client';
 import {
-	ChannelType, ChatInputCommandInteraction, MessageCreateOptions, PermissionFlagsBits 
+	ChatInputCommandInteraction, MessageCreateOptions, PermissionFlagsBits
 } from 'discord.js';
 import { states } from 'src/structures/';
 
@@ -17,7 +17,7 @@ export default async function ping(interaction: ChatInputCommandInteraction<'cac
 	await interaction.deferReply({ ephemeral: true });
 
 	// Get the channel option from the interaction's options, if provided.
-	const channel = interaction.options.getChannel('channel', false, [ChannelType.GuildText]) || interaction.channel;
+	const { channel } = interaction;
 
 	// Check if the bot has permission to send messages in the channel.
 	if (channel.guild && !channel.permissionsFor(interaction.client.user).has(PermissionFlagsBits.SendMessages)) {
@@ -33,8 +33,22 @@ export default async function ping(interaction: ChatInputCommandInteraction<'cac
 	}
 
 	// Get the state role of the interaction member.
-	const stateRole = interaction.options.getRole('role') || states.find((s) => interaction.member.roles.cache.find((r) => r.name === s.abbreviation));
+	const stateAbbreviation = states.find(
+		(s) => interaction.channel.name.toLowerCase() === s.name.toLowerCase()
+			|| interaction.channel.parent?.name.toLowerCase() === s.name.toLowerCase())?.abbreviation;
+	const stateRole = stateAbbreviation && interaction.guild.roles.cache.find((r) => stateAbbreviation.toLowerCase() === r.name.toLowerCase());
 
+	if (!stateRole) {
+		// If the state role is not found, send an error response.
+		return interaction.followUp({
+			content: t({
+				key: 'ping-no-state-role',
+				locale,
+				ns
+			})
+		});
+	}
+	
 	// Create the message content for pinging the role.
 	const pingMessage: MessageCreateOptions = { content: stateRole.toString() };
 


### PR DESCRIPTION
# Fix State Lead Ping

- [x] - There are no unrelated changes
- [x] - Running `yarn test` does not throw any errors
- [x] - I ran `yarn lint` to make sure my codebase is consistent
- [x] - I link to the relevant issues to be closed, if applicable

Uses channel name instead of role guessing to determine what state role to ping