### PR TITLE
More robust /lead ping + fix pinging SME

### DIFF
--- a/locales/en-US/lead.ftl
+++ b/locales/en-US/lead.ftl
@@ -72,16 +72,20 @@ event-option-channel = channel
 event-option-channel-description = Channel for event
 
 ### replies
-event-bad-date = Date is incorrectly formatted
-event-date-past = Date entered was in the past and cannot be used
+event-bad-date = Date is incorrectly formatted.
+event-date-past = Date entered was in the past and cannot be used.
 event-success-create = Successfully created, be sure to add roles or members to the event below.
 event-success-button-event = Event
 event-success-button-vc = Voice Channel
 event-success-button-chat = Text Channel
 event-select-menu = Select Roles or members
 event-select-reply = Permission Override Updated
-event-channel-bad-category = Please choose a channel in the event category
-ping-no-state-role = There was no state role for this channel, please contact staff
+event-channel-bad-category = Please choose a channel in the event category.
+ping-invalid-channel = You are not in a SME or state channel.
+ping-no-state-role = You do not have the corresponding state role to this channel.
+ping-not-state-lead = You must be a state lead to ping the state.
+ping-no-sme-role = You do not have a SME role.
+ping-state-role-not-found = There is not corresponding state role for this channel, please contact the bot developer.
 
 ### Event Modals
 modal-title-event-create = Create Event

--- a/src/structures/index.ts
+++ b/src/structures/index.ts
@@ -18,4 +18,4 @@ export {
 	trackingGuildChecks
 } from './helpers';
 
-export { SMERoleIDs, getSMELeads, getSMERoles, hasSMERole, isSMERole } from './sme';
+export { Channels, SMERoleIDs, getSMELeads, getSMERole, getSMERoles, hasSMERole, isSMERole } from './sme';

--- a/src/structures/sme.ts
+++ b/src/structures/sme.ts
@@ -17,9 +17,14 @@ export function getSMERoles(member: GuildMember) {
 	return SMERoles;
 }
 
-export function hasSMERole(member: GuildMember) {
+export function getSMERole(member: GuildMember) {
 	if (!SMERoleIDs) throw new Error('SME_ROLE_IDS not present in .env');
-	return SMERoleIDs.some((id) => member.roles.cache.has(id));
+	const foundID = SMERoleIDs.find((id) => member.roles.cache.has(id));
+	return member.guild.roles.cache.get(foundID);
+}
+
+export function hasSMERole(member: GuildMember) {
+	return !!getSMERole(member);
 }
 
 export function isSMERole(role: Role) {
@@ -29,3 +34,5 @@ export function isSMERole(role: Role) {
 export async function getSMELeads(role: Role): Promise<GuildMember[]> {
 	return Promise.all(smeConfig[role.id].map((id: string) => role.guild.members.fetch(id)));
 }
+
+export const Channels = ['design', 'coding', 'wiki', 'research-and-analysis', 'public-relations', 'audio-video'];


### PR DESCRIPTION
# Improve /lead ping

- [x] - There are no unrelated changes
- [x] - Running `yarn test` does not throw any errors
- [x] - I ran `yarn lint` to make sure my codebase is consistent
- [x] - I link to the relevant issues to be closed, if applicable

Adds pinging SME roles in skill channels and increases the security around state lead pings with detailed error messages.