### PR TITLE
remove scheduled event partials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import './structures/prototypes';
 import { init } from '@i18n';
 import { Client } from '@progressive-victory/client';
 import {
-	GatewayIntentBits as Intents, Locale, Partials
+	GatewayIntentBits as Intents, Locale, Partials 
 } from 'discord.js';
 import { config } from 'dotenv';
 import { connect } from 'mongoose';
@@ -31,7 +31,7 @@ export const client = new Client({
 		Intents.GuildScheduledEvents,
 		Intents.GuildMessageReactions
 	],
-	partials: [Partials.Message, Partials.Channel, Partials.Reaction, Partials.GuildMember, Partials.GuildScheduledEvent],
+	partials: [Partials.Message, Partials.Channel, Partials.Reaction, Partials.GuildMember],
 	receiveMessageComponents: true,
 	receiveModals: true,
 	receiveAutocomplete: true,


### PR DESCRIPTION
# Fix partial event creation

- [x] - There are no unrelated changes
- [x] - Running `yarn test` does not throw any errors
- [x] - I ran `yarn lint` to make sure my codebase is consistent
- [x] - I link to the relevant issues to be closed, if applicable

Addresses small bug in scheduled events where partials are going through and causing DB verification to fail when making events. The typings don't seem to indicate that there are partials in GuildScheduledEvent, despite it being clearly documented in discord.js on the same version we're on, so this should also address that - we don't want non partials anyway.